### PR TITLE
Fix incorrect use of aliases keyword argument 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: julia
 os:
+    - linux
     - osx
 julia:
     - 0.4

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,7 +3,7 @@ using Compat
 
 @BinDeps.setup
 
-libgsl = library_dependency("libgsl", aliases="libgsl-0")
+libgsl = library_dependency("libgsl", aliases=["libgsl-0"])
 
 # package managers
 provides(AptGet, Dict("libgsl0ldbl"=>libgsl, "libgsl0-dev" =>libgsl, "gsl-bin"=>libgsl))


### PR DESCRIPTION
I think you might need this to avoid going to a docker container build on linux that can't do sudo