### PR TITLE
Return errno instead of gslerrno

### DIFF
--- a/src/35_5_Search_Stopping_Parameters.jl
+++ b/src/35_5_Search_Stopping_Parameters.jl
@@ -38,5 +38,5 @@ function multiroot_test_residual(f::Ref{gsl_vector}, epsabs::Real)
     if gslerrno != SUCCESS && gslerrno != CONTINUE
         throw(GSL_ERROR(errno))
     end
-    gslerrno
+    errno
 end


### PR DESCRIPTION
Harmonize multiroot_test_residual behavior with multiroot_test_delta behavior.  Structure both functions to allow the user to check the integer error code.