### PR TITLE
Fix associated Legendre and sph array

### DIFF
--- a/src/_7_24_1_Legendre_Polynomials.jl
+++ b/src/_7_24_1_Legendre_Polynomials.jl
@@ -127,10 +127,11 @@ end
 #   Returns: Cint
 function sf_legendre_Pl_deriv_array(lmax::Integer, x::Real)
     result_array = Array(Cdouble, lmax+1)
+    result_deriv_array = Array(Cdouble, lmax+1)
     errno = ccall( (:gsl_sf_legendre_Pl_deriv_array, libgsl), Cint, (Cint,
-        Cdouble, Ref{Cdouble}), lmax, x, result_array )
+        Cdouble, Ref{Cdouble}, Ref{Cdouble}), lmax, x, result_array, result_deriv_array )
     if errno!= 0 throw(GSL_ERROR(errno)) end
-    return result_array
+    return (result_array, result_deriv_array)
 end
 @vectorize_2arg Number sf_legendre_Pl_deriv_array
 

--- a/src/_7_24_2_Associated_Legendre_Polynomials_and_Spherical_Harmonics.jl
+++ b/src/_7_24_2_Associated_Legendre_Polynomials_and_Spherical_Harmonics.jl
@@ -42,11 +42,12 @@ end
 # 
 #   Returns: Cint
 function sf_legendre_Plm_array(lmax::Integer, m::Integer, x::Real)
-    result_array = Ref{Cdouble}()
+    @assert lmax >= m
+    result_array = Array(Cdouble, lmax-m+1)
     errno = ccall( (:gsl_sf_legendre_Plm_array, libgsl), Cint, (Cint,
-        Cint, Cdouble, Cdouble), lmax, m, x, result_array )
+        Cint, Cdouble, Ref{Cdouble}), lmax, m, x, result_array )
     if errno!= 0 throw(GSL_ERROR(errno)) end
-    return result_array[][1]
+    return result_array
 end
 #TODO This vectorization macro is not implemented
 #@vectorize_3arg Number sf_legendre_Plm_array
@@ -57,11 +58,12 @@ end
 # 
 #   Returns: Cint
 function sf_legendre_Plm_deriv_array(lmax::Integer, m::Integer, x::Real)
-    result_array = Ref{Cdouble}()
+    @assert lmax >= m
+    result_array = Array(Cdouble, lmax-m+1)
     errno = ccall( (:gsl_sf_legendre_Plm_deriv_array, libgsl), Cint,
-        (Cint, Cint, Cdouble, Cdouble), lmax, m, x, result_array )
+        (Cint, Cint, Cdouble, Ref{Cdouble}), lmax, m, x, result_array )
     if errno!= 0 throw(GSL_ERROR(errno)) end
-    return result_array[][1]
+    return result_array
 end
 #TODO This vectorization macro is not implemented
 #@vectorize_3arg Number sf_legendre_Plm_deriv_array
@@ -106,11 +108,12 @@ end
 # 
 #   Returns: Cint
 function sf_legendre_sphPlm_array(lmax::Integer, m::Integer, x::Real)
-    result_array = Ref{Cdouble}()
+    @assert lmax >= m
+    result_array = Array(Cdouble, lmax-m+1)
     errno = ccall( (:gsl_sf_legendre_sphPlm_array, libgsl), Cint, (Cint,
-        Cint, Cdouble, Cdouble), lmax, m, x, result_array )
+        Cint, Cdouble, Ref{Cdouble}), lmax, m, x, result_array )
     if errno!= 0 throw(GSL_ERROR(errno)) end
-    return result_array[][1]
+    return result_array
 end
 #TODO This vectorization macro is not implemented
 #@vectorize_3arg Number sf_legendre_sphPlm_array
@@ -122,11 +125,12 @@ end
 # 
 #   Returns: Cint
 function sf_legendre_sphPlm_deriv_array(lmax::Integer, m::Integer, x::Real)
-    result_array = Ref{Cdouble}()
+    @assert lmax >= m
+    result_array = Array(Cdouble, lmax-m+1)
     errno = ccall( (:gsl_sf_legendre_sphPlm_deriv_array, libgsl), Cint,
-        (Cint, Cint, Cdouble, Cdouble), lmax, m, x, result_array )
+        (Cint, Cint, Cdouble, Ref{Cdouble}), lmax, m, x, result_array )
     if errno!= 0 throw(GSL_ERROR(errno)) end
-    return result_array[][1]
+    return result_array
 end
 #TODO This vectorization macro is not implemented
 #@vectorize_3arg Number sf_legendre_sphPlm_deriv_array

--- a/src/_7_24_2_Associated_Legendre_Polynomials_and_Spherical_Harmonics.jl
+++ b/src/_7_24_2_Associated_Legendre_Polynomials_and_Spherical_Harmonics.jl
@@ -60,10 +60,11 @@ end
 function sf_legendre_Plm_deriv_array(lmax::Integer, m::Integer, x::Real)
     @assert lmax >= m
     result_array = Array(Cdouble, lmax-m+1)
+    result_deriv_array = Array(Cdouble, lmax-m+1)
     errno = ccall( (:gsl_sf_legendre_Plm_deriv_array, libgsl), Cint,
-        (Cint, Cint, Cdouble, Ref{Cdouble}), lmax, m, x, result_array )
+        (Cint, Cint, Cdouble, Ref{Cdouble}, Ref{Cdouble}), lmax, m, x, result_array, result_deriv_array)
     if errno!= 0 throw(GSL_ERROR(errno)) end
-    return result_array
+    return (result_array, result_deriv_array)
 end
 #TODO This vectorization macro is not implemented
 #@vectorize_3arg Number sf_legendre_Plm_deriv_array
@@ -127,10 +128,11 @@ end
 function sf_legendre_sphPlm_deriv_array(lmax::Integer, m::Integer, x::Real)
     @assert lmax >= m
     result_array = Array(Cdouble, lmax-m+1)
+    result_deriv_array = Array(Cdouble, lmax-m+1)
     errno = ccall( (:gsl_sf_legendre_sphPlm_deriv_array, libgsl), Cint,
-        (Cint, Cint, Cdouble, Ref{Cdouble}), lmax, m, x, result_array )
+        (Cint, Cint, Cdouble, Ref{Cdouble}, Ref{Cdouble}), lmax, m, x, result_array, result_deriv_array)
     if errno!= 0 throw(GSL_ERROR(errno)) end
-    return result_array
+    return (result_array, result_deriv_array)
 end
 #TODO This vectorization macro is not implemented
 #@vectorize_3arg Number sf_legendre_sphPlm_deriv_array

--- a/test/7_24_1_Legendre_Polynomials.jl
+++ b/test/7_24_1_Legendre_Polynomials.jl
@@ -6,6 +6,7 @@ let
     x = 0.5
 
     @test sf_legendre_Pl_array(lmax, x) == [1.0, 0.5, -0.125, -0.4375, -0.2890625]
+    @test length(sf_legendre_Pl_deriv_array(lmax, x)[2]) == lmax + 1
 
     #XXX sf_legendre_Pl_deriv_array(lmax, x) segfaults ?!
 end

--- a/test/7_24_1_Legendre_Polynomials.jl
+++ b/test/7_24_1_Legendre_Polynomials.jl
@@ -6,7 +6,6 @@ let
     x = 0.5
 
     @test sf_legendre_Pl_array(lmax, x) == [1.0, 0.5, -0.125, -0.4375, -0.2890625]
-    @test length(sf_legendre_Pl_deriv_array(lmax, x)[2]) == lmax + 1
+    @test sf_legendre_Pl_deriv_array(lmax, x) == ([1.0,0.5,-0.125,-0.4375,-0.2890625],[0.0,1.0,1.5,0.375,-1.5625])
 
-    #XXX sf_legendre_Pl_deriv_array(lmax, x) segfaults ?!
 end

--- a/test/7_24_2_Associated_Legendre_Polynomials_and_Spherical_Harmonics.jl
+++ b/test/7_24_2_Associated_Legendre_Polynomials_and_Spherical_Harmonics.jl
@@ -2,13 +2,18 @@ using GSL
 using Base.Test
 
 let
-    lmax = 10
-    m = 4
-    x = -0.5
+    lmax = 5
+    m = 2
+    x = 0.5
 
-    @test length(sf_legendre_Plm_array(lmax, m, x)) == lmax - m + 1
-    @test length(sf_legendre_Plm_deriv_array(lmax, m, x)[2]) == lmax - m + 1
-    @test length(sf_legendre_sphPlm_array(lmax, m, x)) == lmax - m + 1
-    @test length(sf_legendre_sphPlm_deriv_array(lmax, m, x)[2]) == lmax - m + 1
+    @test sf_legendre_Plm_array(lmax, m, x)         == [2.25, 5.625, 4.21875, -4.921875]
+    @test sf_legendre_Plm_deriv_array(lmax, m, x)   == ([2.25,5.625,4.21875,-4.921875],
+                                                        [-3.0,3.75,33.75,55.78125])
+    @test sf_legendre_sphPlm_array(lmax, m, x)      == [0.2897056515173923, 0.38324455366248106, 
+                                                        0.18816934037548766, -0.15888479843070935]
+    @test sf_legendre_sphPlm_deriv_array(lmax, m, x) ==     ([0.2897056515173923,0.38324455366248106,
+                                                            0.18816934037548766,-0.15888479843070935],
+                                                            [-0.38627420202318974,0.2554963691083207,
+                                                            1.5053547230039015,1.8006943822147061])
 
 end

--- a/test/7_24_2_Associated_Legendre_Polynomials_and_Spherical_Harmonics.jl
+++ b/test/7_24_2_Associated_Legendre_Polynomials_and_Spherical_Harmonics.jl
@@ -9,6 +9,6 @@ let
     @test length(sf_legendre_Plm_array(lmax, m, x)) == lmax - m + 1
     #XXX sf_legendre_Plm_deriv_array(lmax, m, x) ReadOnlyMemoryError
     @test length(sf_legendre_sphPlm_array(lmax, m, x)) == lmax - m + 1
-    @test length(sf_legendre_sphPlm_deriv_array(lmax, m, x)) == lmax - m + 1
+    #XXX sf_legendre_sphPlm_deriv_array(lmax, m, x) ReadOnlyMemoryError
 
 end

--- a/test/7_24_2_Associated_Legendre_Polynomials_and_Spherical_Harmonics.jl
+++ b/test/7_24_2_Associated_Legendre_Polynomials_and_Spherical_Harmonics.jl
@@ -7,7 +7,7 @@ let
     x = -0.5
 
     @test length(sf_legendre_Plm_array(lmax, m, x)) == lmax - m + 1
-    @test length(sf_legendre_Plm_deriv_array(lmax, m, x)) == lmax - m + 1
+    #XXX sf_legendre_Plm_deriv_array(lmax, m, x) ReadOnlyMemoryError
     @test length(sf_legendre_sphPlm_array(lmax, m, x)) == lmax - m + 1
     @test length(sf_legendre_sphPlm_deriv_array(lmax, m, x)) == lmax - m + 1
 

--- a/test/7_24_2_Associated_Legendre_Polynomials_and_Spherical_Harmonics.jl
+++ b/test/7_24_2_Associated_Legendre_Polynomials_and_Spherical_Harmonics.jl
@@ -1,0 +1,14 @@
+using GSL
+using Base.Test
+
+let
+    lmax = 10
+    m = 4
+    x = -0.5
+
+    @test length(sf_legendre_Plm_array(lmax, m, x)) == lmax - m + 1
+    @test length(sf_legendre_Plm_deriv_array(lmax, m, x)) == lmax - m + 1
+    @test length(sf_legendre_sphPlm_array(lmax, m, x)) == lmax - m + 1
+    @test length(sf_legendre_sphPlm_deriv_array(lmax, m, x)) == lmax - m + 1
+
+end

--- a/test/7_24_2_Associated_Legendre_Polynomials_and_Spherical_Harmonics.jl
+++ b/test/7_24_2_Associated_Legendre_Polynomials_and_Spherical_Harmonics.jl
@@ -7,8 +7,8 @@ let
     x = -0.5
 
     @test length(sf_legendre_Plm_array(lmax, m, x)) == lmax - m + 1
-    #XXX sf_legendre_Plm_deriv_array(lmax, m, x) ReadOnlyMemoryError
+    @test length(sf_legendre_Plm_deriv_array(lmax, m, x)[2]) == lmax - m + 1
     @test length(sf_legendre_sphPlm_array(lmax, m, x)) == lmax - m + 1
-    #XXX sf_legendre_sphPlm_deriv_array(lmax, m, x) ReadOnlyMemoryError
+    @test length(sf_legendre_sphPlm_deriv_array(lmax, m, x)[2]) == lmax - m + 1
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,5 +9,6 @@ include("basic.jl")
 #XXX doesn't work anymore?
 #include("9_Permutations.jl")
 include("7_24_1_Legendre_Polynomials.jl")
+include("7_24_2_Associated_Legendre_Polynomials_and_Spherical_Harmonics.jl")
 include("28_Numerical_Differentiation.jl")
 include("HypergeometricFunctions.jl")


### PR DESCRIPTION
In the file `_7_24_2_Associated_Legendre_Polynomials_and_Spherical_Harmonics.jl`
fixed the below functions
`sf_legendre_Plm_array`
`sf_legendre_Plm_deriv_array`
`sf_legendre_sphPlm_array`
`sf_legendre_sphPlm_deriv_array`
Now they can properly return an array.

Also added a test `7_24_2_Associated_Legendre_Polynomials_and_Spherical_Harmonics.jl` in the test folder.