### PR TITLE
Get older version of GSL on Mac, add 0.5 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
     - osx
 julia:
     - 0.4
+    - 0.5
     - nightly
 notifications:
     email: false

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -15,7 +15,7 @@ if is_apple()
         error("Homebrew package not installed, please run Pkg.add(\"Homebrew\")")
     end
     using Homebrew
-    provides(Homebrew.HB, "gsl", libgsl, os = :Darwin)
+    provides(Homebrew.HB, "homebrew/versions/gsl1", libgsl, os = :Darwin)
 end
 
 if is_windows() 


### PR DESCRIPTION
The default brew downloads version 2.2.1, which has removed a certain
API, and tests fail. So this downloads the old version (1.16) until the
package migrates to support 2.2.1.

This should fix the failing Mac tests as seen in https://github.com/JuliaLang/METADATA.jl/pull/6430. 

cc: @tkelman 