### PR TITLE
Install `gsl@1` instead of `gsl1` for Homebrew

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -15,7 +15,7 @@ if is_apple()
         error("Homebrew package not installed, please run Pkg.add(\"Homebrew\")")
     end
     using Homebrew
-    provides(Homebrew.HB, "homebrew/versions/gsl1", libgsl, os = :Darwin)
+    provides(Homebrew.HB, "gsl@1", libgsl, os = :Darwin)
 end
 
 if is_windows() 


### PR DESCRIPTION
The Homebrew devs have [changed their stance on versioning](http://docs.brew.sh/Versions.html), and are now using `@X` suffixes to denote formulae pegged at version `X` within the main homebrew core repository.